### PR TITLE
Fixing Options Menu Crash

### DIFF
--- a/app/src/main/java/com/example/Dice_Roller/HomeFragment.kt
+++ b/app/src/main/java/com/example/Dice_Roller/HomeFragment.kt
@@ -102,7 +102,6 @@ class HomeFragment: Fragment() {
 
     private fun initHowManySpinner(): Spinner {
 
-
         val howManyStrArray = resources.getStringArray(R.array.saHowManyDice)
         val spinnerHowMany = binding.spnHowManyDice
         spinnerHowMany.adapter = ArrayAdapter(requireContext(), R.layout.spinner_items, howManyStrArray)

--- a/app/src/main/java/com/example/Dice_Roller/MainActivity.kt
+++ b/app/src/main/java/com/example/Dice_Roller/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.forEachIndexed
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.example.diceroller_gridlayoutintro.R
@@ -15,6 +16,7 @@ import com.example.diceroller_gridlayoutintro.databinding.ActivityMainBinding
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
+    private var displayOverflowMenu = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
 
@@ -40,18 +42,33 @@ class MainActivity : AppCompatActivity() {
         return true
 
     }
-
-    //why only work in Main Activity?
+    //why only work in Main Activity? -because onOptionsItemSelected is part of the activity class yes?
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
 
         when(item.itemId) {
-            R.id.settings -> findNavController(R.id.main_fragment).navigate(R.id.navigateToSettingsFragment)
+
+            R.id.settings -> {
+                displayOverflowMenu = false
+                invalidateOptionsMenu()
+                findNavController(R.id.main_fragment).navigate(R.id.navigateToSettingsFragment)
+
+            }
         }
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onSupportNavigateUp(): Boolean {
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
 
+        if(!displayOverflowMenu){
+            displayOverflowMenu = true
+            return false
+        }else {
+            return true
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        invalidateOptionsMenu()
         val navController = findNavController(R.id.main_fragment)
         return navController.navigateUp() || super.onSupportNavigateUp()
     }

--- a/app/src/main/java/com/example/Dice_Roller/SettingsFragment.kt
+++ b/app/src/main/java/com/example/Dice_Roller/SettingsFragment.kt
@@ -1,6 +1,8 @@
 package com.example.Dice_Roller
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
 import androidx.preference.PreferenceFragmentCompat
 import com.example.diceroller_gridlayoutintro.R
 
@@ -9,4 +11,5 @@ class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.root_preferences, rootKey)
     }
+
 }


### PR DESCRIPTION
Modified onOptionsItemSelected, onPrepareOptionsMenu, and onSupportNavigateUp to provide logic so the options menu is visible and invisible where required