### PR TITLE
Fixing UI Bug on Return to Home Fragment

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,6 +7,8 @@
         <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/DiceRollerGridLayoutIntro/app/src/main/res/layout/die_result.xml" value="0.32019927536231885" />
         <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/DiceRollerGridLayoutIntro/app/src/main/res/layout/die_result_grid_layout.xml" value="0.3333333333333333" />
         <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/DiceRollerGridLayoutIntro/app/src/main/res/layout/spinner_items.xml" value="0.3333333333333333" />
+        <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/Dice_Roller/app/src/main/res/drawable/rounded_button.xml" value="0.3536458333333333" />
+        <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/Dice_Roller/app/src/main/res/layout-v26/home_fragment.xml" value="0.3333333333333333" />
         <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/Dice_Roller/app/src/main/res/layout/activity_main.xml" value="0.3120471014492754" />
         <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/Dice_Roller/app/src/main/res/layout/die_result.xml" value="0.3120471014492754" />
         <entry key="..\:/Users/Phil Kagebein/AndroidStudioProjects/Dice_Roller/app/src/main/res/layout/die_result_grid_layout.xml" value="0.3120471014492754" />

--- a/app/src/main/java/com/example/dice_Roller/HomeFragment.kt
+++ b/app/src/main/java/com/example/dice_Roller/HomeFragment.kt
@@ -90,7 +90,6 @@ class HomeFragment: Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
 
         when(item.itemId) {
-
             R.id.settings -> {
                 findNavController().navigate(R.id.navigateToSettingsFragment)
             }

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -24,17 +24,15 @@
             android:layout_width="match_parent"
             android:layout_height="70dp"
             android:layout_marginHorizontal="60dp"
-            android:layout_marginBottom="35dp"
+            android:layout_marginVertical="35dp"
             android:text="@string/roll"
-            android:textSize="40sp"
-            android:gravity="bottom|center"
+            android:autoSizeTextType="uniform"
+            android:gravity="center|bottom"
             android:background="@drawable/rounded_button"
-            android:backgroundTint="?attr/primaryColor"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-
-            />
+             />
 
         <!--How Many text and spinner-->
         <TextView


### PR DESCRIPTION
When returning to the home fragment from the settings page, there was a thin vertical line which would briefly appear over the roll button. This has been fixed.